### PR TITLE
make xsch log file

### DIFF
--- a/make/core.make
+++ b/make/core.make
@@ -146,7 +146,7 @@ gds:
 
 xsch:
 	@test -d xsch || mkdir xsch
-	-xschem -q -x -b -s -n ../design/${LIB}/${CELL}.sch
+	-xschem -q -x -b -s -n ../design/${LIB}/${CELL}.sch -l xsch/xsch_${CELL}.log
 	cp xsch/${CELL}.spice xsch/${CELL}.spice.bak
 	cat xsch/${CELL}.spice.bak | perl ../tech/script/fixsubckt > xsch/${CELL}.spice
 	-rm xsch/${CELL}.spice.bak


### PR DESCRIPTION
It seems like many students gets stuck due to errors when performing "make xsch". This is also the case when this command is run when the students are performing simulations. Giving them easier access to the output of Xschem in the form of a log file will make it easier to figure out what is causing the errors and will keep the terminal clean. Also, it will teach them to troubleshoot using log files and to become more independent.

Running `xschem -q -x -b -s -n ../design/${LIB}/${CELL}.sch` will not always result in an error even though the same command results in an error when using `make xsch`. A case where this is true is when there is an existing symbol for a CELL that does not have the same amount of pins as in the schematic. Looking at the output from Xschem in the terminal or in a log file would make this clear right away.