### PR TITLE
docs: audit against the tools — fix corner letters, gamma, and the cicconf flow

### DIFF
--- a/cic/sky130A.tech.md
+++ b/cic/sky130A.tech.md
@@ -49,12 +49,34 @@ Global constants:
 
 | Key | Value | Meaning |
 |:-|:-|:-|
-| `gamma` | 100 | Internal units per micron: rules below are in nanometres |
-| `grid` | 5 | Manufacturing grid |
-| `spiceunit` | 1 | Scale factor for device properties in the netlist |
+| `gamma` | 100 | Ångström per rule unit, so every rule below is in units of 100 Å = 10 nm |
+| `grid` | 5 | Snap grid for ciccreator |
+| `spiceunit` | 1 | Scale for device properties in the netlist |
 | `techlib` | `sky130A` | PDK library name |
 | `symbol_lib` | `cpdk` | Default xschem symbol library |
 | `symbol_libs` | list | Where to look for symbols: `cpdk` design dirs and the PDK's `sky130_fd_pr` |
+
+### Units
+
+The internal coordinate system is **ångström**. In cicpy, `Cell.toMicron` is
+`(angstrom/10)/1000.0` and a layout cell carries `um = 10000`, so there are
+10 000 internal units in a micron.
+
+`gamma` is what gets a rule into that system: `Rules.get()` returns
+`rule_value * gamma`. With `gamma = 100`, a rule of `30` is 3000 Å, which is
+0.3 µm. So the numbers in the `rules` section are in steps of 10 nm, not in
+nanometres and not in internal units.
+
+A worked example from the history of this file: `VIA4` (magic's via3) was
+changed from `28` to `32` in a commit titled "legal VIA4 size", which is
+0.28 µm → 0.32 µm, sky130's exact via3 size.
+
+Magic output is a third scale again. `MagicPrinter.toMicron` is
+`round(angstrom/50)`, snapping to the 50 Å = 5 nm sky130 grid; that 50 is
+hard coded in cicpy and does not come from `grid`.
+
+`grid` and `spiceunit` are read into cicpy's `Rules` object and then never
+used by it, so whatever they do, they do it on the ciccreator side.
 
 `devices` maps a ciccreator device name to the PDK subcircuit it netlists as,
 its `devicetype` prefix and its port order:
@@ -72,7 +94,8 @@ its `devicetype` prefix and its port order:
 
 ## rules
 
-34 rule groups, all in nanometres. A rule is either a plain minimum
+34 rule groups, all in units of 10 nm (see [Units](#units) above: the value
+is multiplied by `gamma` to give ångström). A rule is either a plain minimum
 (`width`, `space`, `minwidth`, `minlength`) or a relationship between two
 layers, written as `<OTHER>enclosure` and `<OTHER>encOpposite` (enclosure
 along and across the shape):
@@ -83,6 +106,9 @@ along and across the shape):
          "VIA1enclosure": 3, "VIA1encOpposite": 6, "PTAPCenclosure": 0 }
 ```
 
+Read that as: 0.30 µm minimum width and spacing, 0.40 µm when the metal is a
+capacitor plate, and 0.03 µm of enclosure along a VIA1 with 0.06 µm across it.
+
 `ROUTE` is the router's view of the stack rather than a DRC rule:
 
 ```json
@@ -92,10 +118,12 @@ along and across the shape):
             "directions": { "M2": "v", "M3": "h", "M4": "v", "M5": "h" } }
 ```
 
-`costs` biases the router towards the cheap layers, `directions` fixes the
-preferred direction per layer, and `pinlayer`/`pintravel` say that pins are on
-`M1` and that the router may travel vertically on the pin layer, which is the
-cheapest thing it can do.
+The two grids are on the same 10 nm scale as everything else, so routing is on
+a 0.30 µm horizontal and 0.40 µm vertical pitch. `costs` biases the router
+towards the cheap layers, `directions` fixes the preferred direction per
+layer, and `pinlayer`/`pintravel` say that pins are on `M1` and that the
+router may travel vertically on the pin layer, which is the cheapest thing it
+can do.
 
-`CELL` holds the placement pitch (`space` 20, `digitalspace` 18) rather than a
-geometric rule.
+`CELL` holds the placement pitch (`space` 20 = 0.20 µm, `digitalspace` 18 =
+0.18 µm) rather than a geometric rule.

--- a/cic/sky130A.tech.md
+++ b/cic/sky130A.tech.md
@@ -68,8 +68,9 @@ The internal coordinate system is **ångström**. In cicpy, `Cell.toMicron` is
 nanometres and not in internal units.
 
 A worked example from the history of this file: `VIA4` (magic's via3) was
-changed from `28` to `32` in a commit titled "legal VIA4 size", which is
-0.28 µm → 0.32 µm, sky130's exact via3 size.
+changed from `28` to `32` in a commit titled "legal VIA4 (magic via3) size",
+which on this scale is 0.28 µm → 0.32 µm. Whatever the PDK requires, it is a
+sub-micron via dimension, which is the corroboration that matters here.
 
 Magic output is a third scale again. `MagicPrinter.toMicron` is
 `round(angstrom/50)`, snapping to the 50 Å = 5 nm sky130 grid; that 50 is

--- a/cicconf/README.md
+++ b/cicconf/README.md
@@ -5,13 +5,47 @@ that clones an IP's dependencies and scaffolds a new IP repository.
 
 ```bash
 cicconf --config config.yaml clone --https      # fetch dependencies
-cicconf template ../tech/cicconf/jnw.yaml       # make a new IP
+cicconf newip bias                              # make a new IP
 ```
 
-A template is one yaml file describing a whole repository: the directories to
-create, the files to write with `${IP}` and `${CELL}` substituted, and the
-commands to run afterwards. All four here build the same shape of repository
-and differ only in the details.
+`newip` does not take the template path. It reads it from the `options` block
+of the *monorepo* `config.yaml` you run it in:
+
+```yaml
+options:
+  project: JNW
+  technology: SKY130A
+  template:
+    ip: ../tech_sky130A/cicconf/jnw.yaml
+```
+
+so `cicconf newip bias` creates `JNW_BIAS_SKY130A` in a directory named
+`jnw_bias_sky130a`. `--project`, `--technology` and `--ip` override the three
+values for one invocation, which is how you use a template that is not the
+project default:
+
+```bash
+cicconf newip bias --ip ../tech_sky130A/cicconf/lelo.yaml
+```
+
+A template is one yaml file describing a whole repository. cicconf substitutes
+into it before parsing it as yaml, then runs the keys it recognises in order:
+
+| Key | What it does |
+|:-|:-|
+| `dirs` | Directories to create |
+| `create` | `filename: contents` pairs to write |
+| `do` | Shell commands to run in the new directory |
+| `echo` | A message to print at the end |
+| `copy` | Files to copy from a source IP; only does anything with `--src`, which `newip` does not pass |
+
+The substitutions are `${IP}`, `${CELL}` and their lowercase forms `${ip}` and
+`${cell}`, followed by environment variables. `${CELL}` is not something you
+choose: it is the IP name with its last underscore-separated segment removed,
+so `JNW_BIAS_SKY130A` gives `JNW_BIAS`.
+
+All four templates here build the same shape of repository and differ only in
+the details.
 
 | Template | Standard cells | Extras |
 |:-|:-|:-|

--- a/cicconf/ip_template.yaml.md
+++ b/cicconf/ip_template.yaml.md
@@ -2,8 +2,11 @@
 
 The generic IP template, and the one to copy when starting a new flow.
 
+Point `options.template.ip` at it in your monorepo `config.yaml`, or select it
+for one IP on the command line:
+
 ```bash
-cicconf template ../tech/cicconf/ip_template.yaml
+cicconf newip <name> --ip ../tech_sky130A/cicconf/ip_template.yaml
 ```
 
 ## dirs

--- a/cicsim/cell_spice/summary.yaml.md
+++ b/cicsim/cell_spice/summary.yaml.md
@@ -21,14 +21,27 @@ simulations:
         method: 3std
 ```
 
-One entry per column of the table. `src` is the result directory a corner run
-wrote, and `method` says how to reduce the runs in it to a single number:
+The key under `simulations` is the testbench name, and it is load bearing:
+cicsim reads the specification from `<key>.yaml`, so `tran:` here is what
+makes [tran.yaml](tran.yaml.md) the spec file. Rename the testbench and this
+key has to follow, or the table comes out empty.
 
-| Method | Reduction |
-|:-|:-|
-| `typical` | The single typical run |
-| `minmax` | Worst case over every run in the set |
-| `3std` | Mean ± 3 standard deviations, for the Monte Carlo set |
+Under `data`, one entry per column of the table. `src` is the result directory
+a corner run wrote, and `method` says how to reduce the runs in it:
+
+| Method | Typical column | Min / max columns |
+|:-|:-|:-|
+| contains `typ` | median | none |
+| contains `3std` | mean | mean ± 3σ |
+| contains `std` | mean | mean ± 1σ |
+| anything else | median | the actual min and max of the set |
+
+The match is a substring test in the order above, so `typical` selects the
+first row and `minmax` falls through to the last. Two consequences worth
+knowing: `typical` reports the **median** of whatever runs are in that
+directory, not "the one typical run" — it only looks like a single value
+because the set usually holds one — and `minmax` reports a real minimum and
+maximum, so it is the honest worst case rather than a σ estimate.
 
 The three defaults line up with the `typical`, `etc` and `mc` targets of the
 [Makefile](Makefile.md), which is why plain `make` runs exactly those before

--- a/cicsim/cell_spice/template.yaml.md
+++ b/cicsim/cell_spice/template.yaml.md
@@ -28,9 +28,20 @@ so the view can be named on the command line and end up in the result
 directory name. [tran.spi](tran.spi.md) then switches on `Lay` with `#ifdef` to
 include the extracted netlist instead of the schematic one.
 
-`sha: True` records the netlist hash with the results, so a stale result is
-recognisable. `useTmpDir: False` keeps the run in place, which makes debugging
-a failed simulation much easier.
+`sha: True` is a caching switch, not a bookkeeping one. cicsim hashes every
+input file it references, saves them as `<run>.sha`, and on the next run
+compares. If nothing has changed it prints "No spice files have changed" and
+**skips the simulation entirely**; the `.meas` file is hashed separately, so
+an unchanged measurement file on top of a skipped simulation skips the
+measurement run too. That is what makes a repeated `make typical` cheap, and
+also why a run that "did nothing" is usually correct rather than broken. Pass
+`--no-sha` to force it.
+
+`useTmpDir: False` keeps the run directory where it is. With it on, cicsim
+puts the run under `/tmp/cicsim/$USER/<lib>/<cell>/<rundir>`, symlinks it into
+place, and rewrites `../` in every `.include` and `.lib` to an absolute path
+so the relocated netlist still resolves. Off is the easier thing to debug,
+since the files are simply there.
 
 ## copy
 

--- a/cicsim/cell_spice/tran.meas.md
+++ b/cicsim/cell_spice/tran.meas.md
@@ -3,6 +3,12 @@
 Measurements to run on the raw file after the simulation, as an ngspice
 `.control` block.
 
+This is a **second ngspice invocation**, not part of the first: cicsim runs
+`ngspice -b <run>.meas` once the simulation is done and captures the output in
+`<run>.logm`. That is why the file starts by loading the raw file the
+simulation left behind, and why an expensive measurement costs you nothing on
+the simulation itself.
+
 ```spice
 .control
 load {cicname}.raw
@@ -13,9 +19,9 @@ echo "MEAS_END"
 
 `{cicname}` is substituted by cicsim with the name of the run.
 
-The template is empty on purpose: everything printed between `MEAS_START` and
-`MEAS_END` is parsed by cicsim into the result yaml, keyed by name. Add
-measurements between the two echoes:
+The template is empty on purpose: the two echoes mark the region of
+`<run>.logm` that cicsim parses, as `key = value` pairs and as tables. Add
+measurements between them:
 
 ```spice
 meas tran vout_final FIND v(OUT) AT=9n

--- a/cicsim/cell_spice/tran.py.md
+++ b/cicsim/cell_spice/tran.py.md
@@ -16,3 +16,21 @@ the yaml back. Whatever ends up in the file is what the summary table reports.
 
 This is where a derived figure of merit belongs: an ENOB from a measured SNR,
 a gain from two measured voltages, a yield from a Monte Carlo set.
+
+## When it runs, and what it is handed
+
+After every simulation in the invocation has succeeded, and before cicsim
+collects the results. One failed simulation and the whole post-processing step
+is skipped, so a missing derived number usually means a failed corner rather
+than a broken script.
+
+cicsim imports the module once and calls `main` for each run, inspecting the
+signature first:
+
+```python
+def main(name):                 # name of the run, e.g. tran_Sch_typical_Ktt...
+def main(name, corner):         # also gets the corner, if you declare it
+```
+
+Declaring the second parameter is how a script behaves differently per corner
+without parsing the run name.

--- a/cicsim/cell_spice/tran.yaml.md
+++ b/cicsim/cell_spice/tran.yaml.md
@@ -18,8 +18,11 @@ template is all comments, showing the fields:
 
 cicsim uses this when it builds the summary table: `min` and `max` decide
 whether a result passes, `scale`, `digits` and `unit` decide how it is
-displayed, and `name` is the human readable label. `src` names the measurements
-a derived entry is computed from.
+displayed, and `name` is the human readable label. `desc` is accepted too,
+though the template does not mention it.
 
-A measurement with no entry here still appears in the results; it just has no
-specification to be judged against.
+`src` is the selector, not a formula: it names the measurement column, or a
+list of columns, that this entry covers, and the summary keeps only the
+columns some spec names. So a measurement with no entry here is not merely
+unjudged — it is dropped from the table. Defaults if you omit a field are
+`unit: V`, `scale: 1`, `typ: 0`, `digits: 2`.

--- a/cicsim/cicsim.yaml.md
+++ b/cicsim/cicsim.yaml.md
@@ -26,15 +26,44 @@ netlist when that corner is selected. Pick one from each group.
 | General | `Gt` | nothing, it is a placeholder |
 | Temperature | `Tt` `Tl` `Tm` `Th` | [ngspice/temperature.spi](../ngspice/temperature.spi.md) |
 | Supply | `Vt` `Vl` `Vh` | [ngspice/supply.spi](../ngspice/supply.spi.md) |
-| Process | `Ktt` `Kss` `Kff` `Ksf` `Kfs` `Khh` `Khl` `Klh` `Kll` | the PDK model files |
+| Process | `Ktt` `Kss` `Kff` `Ksf` `Kfs` `Khh` `Khl` `Klh` `Kll` | the PDK model files, spelled out |
 | Process, Monte Carlo | the same with an `mm` suffix, plus `Kmc` | the PDK, with the mc switches on |
-| Analog model set | `Att` `Ass` `Aff` `Asf` `Afs` `All` `Ahh` `Ahl` `Alh` and `Amc...` | the PDK |
+| Process, short form | `Att` `Ass` `Aff` `Asf` `Afs` `Ahh` `Ahl` `Alh` `All` and `Amc...` | one `.lib` into the PDK's `sky130.lib.spice` |
 
-The two letters in a process corner name are the device corner and the
-parasitic corner: `Kss` is slow devices with the typical RC set, `Khl` is high
-resistance with low capacitance, and so on. The `mm` variants set
-`mc_mm_switch=1` for mismatch, `Kmc` sets `mc_pr_switch=1` for process
-variation.
+## What the two letters mean
+
+They are one sky130 corner name, not a device choice and an RC choice picked
+independently. Two families:
+
+| Corner | FET models | Resistance | Capacitance |
+|:-|:-|:-|:-|
+| `Ktt` | tt | typical | typical |
+| `Kss` | ss | high | high |
+| `Kff` | ff | low | low |
+| `Ksf` | sf | typical | typical |
+| `Kfs` | fs | typical | typical |
+| `Khh` | tt | high | high |
+| `Khl` | tt | high | low |
+| `Klh` | tt | low | high |
+| `Kll` | tt | low | low |
+
+In the first family the letters are the device corner, nfet then pfet, and
+the `r+c` set follows it: `Kss` pulls in `res_high__cap_high`, `Kff` pulls in
+`res_low__cap_low`, and the skewed corners stay on typical RC. In the second
+family the devices are typical and the letters are the parasitic corner
+instead, resistance then capacitance. `Khh` is `Kss`'s parasitics without
+`Kss`'s devices.
+
+The `mm` variants set `mc_mm_switch=1` on the same includes, for mismatch.
+`Kmc` is not a corner in that sense at all: it includes only
+`parameters/critical.spice` and `parameters/montecarlo.spice` with
+`mc_pr_switch=1`.
+
+The `A...` names are the identical corners as a single
+`.lib "$PDK_ROOT/.../sky130.lib.spice" <xy>` line, and `Amc...` maps to the
+PDK's `<xy>_mm` sections. `K...` exists because
+[py/genyaml](../py/genyaml.md) expanded those sections into explicit
+includes, which is what makes each corner's real content visible here.
 
 The temperature and supply corners are one-line `.lib` references, so the
 actual values live in one place and are edited there.

--- a/cicsim/cicsim.yaml.md
+++ b/cicsim/cicsim.yaml.md
@@ -13,8 +13,12 @@ cd sim && ln -s ../tech/cicsim/cicsim.yaml
 
 ## variable
 
-`CPDK_NGPICE: ../../../`, the path a testbench uses to reach the cpdk spice
-models from inside `sim/<CELL>/`.
+`CPDK_NGPICE: ../../../`.
+
+Note that cicsim 0.2.7 does not read this key. The only top-level keys it
+looks at are `ngspice`, `spectre`, `cadence`, `corner` and `options`, so
+whatever consumes `variable` is either older, newer, or somewhere else
+entirely. Do not assume changing it does anything.
 
 ## corner
 

--- a/guide/01-getting-started.md
+++ b/guide/01-getting-started.md
@@ -54,13 +54,26 @@ needed by some of the [scripts](../script/README.md), and `gdstk` by
 
 ## 3. Make an IP
 
-Pick a template from [cicconf/](../cicconf/README.md) and run it in the
-directory that will hold your repositories:
+From the directory that holds your repositories, with a `config.yaml` naming
+the project, the technology and the template to use:
+
+```yaml
+options:
+  project: JNW
+  technology: SKY130A
+  template:
+    ip: ../tech_sky130A/cicconf/jnw.yaml
+```
 
 ```bash
-mkdir ~/work && cd ~/work
-cicconf template ../tech/cicconf/jnw.yaml
+cd ~/work
+cicconf newip bias
 ```
+
+The IP is named `<project>_<name>_<technology>`, so that gives
+`JNW_BIAS_SKY130A` in a directory called `jnw_bias_sky130a`. Add
+`--ip <path>` to use a template other than the one in `config.yaml`, and see
+[cicconf/](../cicconf/README.md) for what the four here differ in.
 
 That creates the repository, writes the CI workflows, makes the first commit,
 and lays down the symlinks the flow depends on:
@@ -71,12 +84,12 @@ and lays down the symlinks the flow depends on:
 ├── cpdk/                   borders and shared symbols
 ├── jnw_tr_sky130A/         standard cells
 ├── jnw_atr_sky130A/        analog transistor library
-└── my_ip/
+└── jnw_bias_sky130a/
     ├── tech -> ../tech_sky130A
     ├── config.yaml         what to clone
     ├── info.yaml           who you are, what the docs say
-    ├── design/MY_IP_SKY130A/
-    │   ├── MY_CELL.sch
+    ├── design/JNW_BIAS_SKY130A/
+    │   ├── JNW_BIAS.sch          ${CELL}, the IP name less its last segment
     │   └── JNW_TR_SKY130A -> ../../../jnw_tr_sky130A/design/JNW_TR_SKY130A
     ├── work/               where you run make
     ├── sim/                where you run cicsim
@@ -86,7 +99,7 @@ and lays down the symlinks the flow depends on:
 On an IP that already exists, clone its dependencies instead:
 
 ```bash
-cd my_ip
+cd jnw_bias_sky130a
 cicconf --rundir ../ --config config.yaml clone --https
 ```
 

--- a/guide/03-simulation.md
+++ b/guide/03-simulation.md
@@ -145,10 +145,16 @@ Then:
 make summary    # writes README.md with the table
 ```
 
-`summary.yaml` decides the columns: the typical run, worst case over the `etc`
-set, and mean ± 3σ over the Monte Carlo set. Add a `Lay_typ` entry pointing at
-`results/tran_Lay_typical` to get the post-layout column beside the schematic
-one.
+`summary.yaml` decides the columns, and its `method` decides how each result
+directory is reduced: the median over the `typical` set, the real min and max
+over the `etc` set, and mean ± 3σ over the Monte Carlo set. Add a `Lay_typ`
+entry pointing at `results/tran_Lay_typical` to get the post-layout column
+beside the schematic one. See
+[summary.yaml](../cicsim/cell_spice/summary.yaml.md) for the exact reductions.
+
+Only measurements that some entry in `tran.yaml` names in its `src` reach the
+table at all, so a measurement you added and cannot find is usually one you
+never gave a spec.
 
 The README that comes out is what the documentation action publishes, so a
 simulation that is worth keeping should end with `make summary`.

--- a/guide/03-simulation.md
+++ b/guide/03-simulation.md
@@ -11,13 +11,44 @@ A run picks one value from each of four groups. The names are terse, so:
 | Group | Names | Means |
 |:-|:-|:-|
 | General | `Gt` | Nothing; a placeholder so the position is always filled |
-| Process | `Ktt` `Kss` `Kff` `Ksf` `Kfs` `Khh` `Khl` `Klh` `Kll` | Two letters: device corner, then RC corner |
+| Process | `Ktt` `Kss` `Kff` `Ksf` `Kfs` `Khh` `Khl` `Klh` `Kll` | One PDK corner name, see below |
 | Temperature | `Tt` 27 °C, `Tl` −40 °C, `Th` 125 °C, `Tm` 42.4 °C | [ngspice/temperature.spi](../ngspice/temperature.spi.md) |
 | Supply | `Vt` 1.8 V, `Vl` 1.7 V, `Vh` 1.9 V | [ngspice/supply.spi](../ngspice/supply.spi.md) |
 
-So `Kss` is slow devices with typical parasitics, `Ksf` is slow n and fast p,
-`Khl` is high resistance with low capacitance. Add `mm` for mismatch
-(`Kttmm`), and `Kmc` turns on process variation.
+The two letters after `K` are one sky130 corner name, not two independent
+choices, and they come in two families:
+
+| Corner | FET models | Resistance | Capacitance |
+|:-|:-|:-|:-|
+| `Ktt` | tt | typical | typical |
+| `Kss` | ss | **high** | **high** |
+| `Kff` | ff | **low** | **low** |
+| `Ksf` | sf | typical | typical |
+| `Kfs` | fs | typical | typical |
+| `Khh` | **tt** | high | high |
+| `Khl` | **tt** | high | low |
+| `Klh` | **tt** | low | high |
+| `Kll` | **tt** | low | low |
+
+So in `Kss`/`Kff`/`Ksf`/`Kfs` the letters name the *device* corner, nfet then
+pfet, and the parasitics come along for the ride: slow devices are shipped
+with high R and high C, fast devices with low R and low C, and the skewed
+corners keep typical RC. In `Khh`/`Khl`/`Klh`/`Kll` the devices are typical
+and the letters name the *parasitic* corner instead, resistance then
+capacitance.
+
+`Kss` is therefore not "slow devices, typical parasitics" — it is slow
+devices with the pessimistic RC as well. If you want a device corner against
+a different RC set, there is no name for it; run the RC corner separately.
+
+Add `mm` for mismatch (`Kttmm`, `Kssmm`, ...), which sets `mc_mm_switch=1` on
+top of the same includes. `Kmc` is different again: it includes only the
+Monte Carlo parameter files with `mc_pr_switch=1`, for process variation.
+
+The `A...` names are the same corners written the short way: `Att` is a
+one-line `.lib` into the PDK's own `sky130.lib.spice`, where `K...` spells
+out every include that section would pull in. `Amctt` is the PDK's `tt_mm`
+section. Use whichever you prefer; they resolve to the same models.
 
 Two more, from the local `cicsim.yaml` the testbench template writes: `Sch`
 and `Lay`. Both are empty corners. They add nothing to the netlist and exist so

--- a/magic/lpe.tcl.md
+++ b/magic/lpe.tcl.md
@@ -15,8 +15,11 @@ ext2spice cthresh 0.01
 ext2spice -p lpe/ext -o lpe/{CELL}_lpe.spi
 ```
 
-`cthresh 0.01` keeps every capacitor down to 0.01 fF. Lower it to catch more,
-raise it for a netlist that simulates in reasonable time.
+`cthresh 0.01` is magic's capacitance threshold: capacitors below it are
+dropped. Lower it to catch more, raise it for a netlist that simulates in
+reasonable time. Check magic's own documentation for the units before reading
+much into the number; what is certain here is that this flow keeps far more
+capacitance than [lpeh.tcl](lpeh.tcl.md), which uses `0.1`.
 
 Resistance is *not* extracted; use [lper.tcl](lper.tcl.md) for that.
 

--- a/magic/lpeh.tcl.md
+++ b/magic/lpeh.tcl.md
@@ -11,8 +11,8 @@ ext2spice resistor off
 ext2spice cthresh 0.1
 ```
 
-The threshold is ten times looser than the flat flow (0.1 fF) and resistors are
-off, because a hierarchical extraction is used when the flat one is too big to
-finish. The netlist keeps the cell hierarchy, which makes it much smaller and
+The capacitance threshold is ten times looser than the flat flow (`0.1`
+against `0.01`) and resistors are off, because a hierarchical extraction is
+used when the flat one is too big to finish. The netlist keeps the cell hierarchy, which makes it much smaller and
 much faster to simulate, at the cost of missing every coupling capacitance
 between cells.

--- a/magic/lper.tcl.md
+++ b/magic/lper.tcl.md
@@ -21,8 +21,10 @@ ext2spice cthresh 0.01
 
 Resistance extraction in magic is a two step affair: `extresist` needs the
 `.sim` file that `ext2sim` writes, and only then can `ext2spice extresist on`
-merge the resistor network into the spice netlist. `tolerance 10` is the
-percentage below which a resistance is not worth splitting a node for.
+merge the resistor network into the spice netlist. `tolerance 10` controls how
+aggressively `extresist` simplifies that network; raising it gives fewer nodes
+and a faster simulation. Magic's documentation is the place to check what the
+value is measured in.
 
 `cellname delete {CELL}` drops the unflattened original so the flattened copy
 is unambiguously the top cell.

--- a/ngspice/corners.spi.md
+++ b/ngspice/corners.spi.md
@@ -10,14 +10,19 @@ It holds one `.lib` per corner name, 41 of them. Three kinds:
   the matching block of [temperature.spi](temperature.spi.md) or
   [supply.spi](supply.spi.md).
 - **Process corners.** `Ktt`, `Kss`, `Kff`, `Ksf`, `Kfs`, `Khh`, `Khl`, `Klh`,
-  `Kll` include the sky130 model files for that combination of device and
-  parasitic corner, with `mc_mm_switch` and `mc_pr_switch` both 0.
+  `Kll` include the sky130 nfet, pfet, non-FET and `r+c` model files for one
+  named PDK corner, with `mc_mm_switch` and `mc_pr_switch` both 0. The two
+  letters are that corner's name: for `ss`/`ff`/`sf`/`fs` they are the device
+  corner and the parasitics follow it, for `hh`/`hl`/`lh`/`ll` the devices are
+  typical and the letters are resistance and capacitance. See
+  [cicsim.yaml](../cicsim/cicsim.yaml.md) for the full table.
 - **Monte Carlo variants.** The same names with an `mm` suffix (`Kttmm`,
   `Kssmm`, ...) set `mc_mm_switch=1` for mismatch, and `Kmc` sets
   `mc_pr_switch=1` for process variation.
 
-The `A...` names (`Att`, `Ass`, `Amctt`, ...) are the same idea for the analog
-model set.
+The `A...` names (`Att`, `Ass`, `Amctt`, ...) are the same corners as a single
+`.lib` line into the PDK's `sky130.lib.spice`, rather than the expanded
+include list.
 
 Paths into the PDK are written with `$PDK_ROOT` rather than the absolute
 `/opt/pdk/share/pdk` they were parsed from, which is the `--replace` option of


### PR DESCRIPTION
Two errors you caught, plus everything else I found when I audited the rest the same way: against the code that reads the data, not the data alone.

Verified against **cicconf 0.1.9**, **cicsim 0.2.7**, **cicpy 0.1.10** (from PyPI) and the repo itself.

## The three that mattered

**1. `cicconf template <file>` does not exist.** cicconf's commands are `clone`, `newip`, `status`, `update`, `pull`. `newip` takes a *name*, not a template path — the template comes from `options.template.ip` in the monorepo `config.yaml`, or `--ip`. The IP is `<project>_<name>_<technology>` uppercased, in a lowercase directory, and `${CELL}` is that name less its last underscore segment (`JNW_BIAS_SKY130A` → `JNW_BIAS`). This was in the getting-started guide, so it was the first command a new user would have run, and it would have failed.

**2. `gamma` is ångström per rule unit**, not "internal units per micron", and the rules are not in nanometres. From cicpy: `toMicron(angstrom) = (angstrom/10)/1000.0`, `um = 10000`, `Rules.get() -> value * gamma`. With `gamma = 100` a rule of `30` is 3000 Å = 0.3 µm, so **rules are in steps of 10 nm**. The old line was self-contradictory: 100 units per micron makes a unit 10 nm, not 1 nm.

**3. The two letters in a `K` corner are one sky130 corner name**, not "device corner, then RC corner":

| Corner | FET models | `r+c` set |
|:-|:-|:-|
| `Ktt` | tt | `res_typical__cap_typical` |
| `Kss` | ss | `res_high__cap_high` |
| `Kff` | ff | `res_low__cap_low` |
| `Ksf` / `Kfs` | sf / fs | `res_typical__cap_typical` |
| `Khh` `Khl` `Klh` `Kll` | **tt** | high/low R × high/low C |

In `ss`/`ff`/`sf`/`fs` the letters are the device corner (nfet, then pfet) and the parasitics follow the devices. In `hh`/`hl`/`lh`/`ll` the devices are typical and the letters are R and C. So `Kss` is *not* "slow devices with typical parasitics" — it carries the pessimistic RC too, and `Khh` is the one that isolates those parasitics.

## Also wrong, also fixed

- **`sha: True` is a cache, not bookkeeping.** Matching hashes make cicsim *skip* the simulation ("No spice files have changed") and, separately, the measurement run. I had it as "records the netlist hash so a stale result is recognisable".
- **`useTmpDir: True`** relocates the run under `/tmp/cicsim/$USER/...`, symlinks it into place and rewrites relative `.include`/`.lib` paths to absolute — which is the real reason to leave it off.
- **Summary `method`**: `typical` is the **median** of the set, not "the single typical run"; `minmax` gives a real min and max; there is also a `std` method I had omitted; and matching is a substring test.
- **`tran.meas` is a second ngspice invocation** writing `<run>.logm`. `MEAS_START`/`MEAS_END` bracket the parsed region of *that* log.
- **`tran.py`**: `main` may be `(name)` or `(name, corner)` — cicsim inspects the signature. It runs after every simulation succeeds, before results are collected.
- **`tran.yaml` `src`** selects which measurement columns a spec covers. A measurement no spec names is **dropped** from the table, not merely unjudged.
- **`summary.yaml`'s key under `simulations`** must equal the testbench name — the spec file is loaded as `<key>.yaml`.
- **The `A...` corners** are not "the analog model set": `Att` is a one-line `.lib` into the PDK's `sky130.lib.spice`, the same corner `Ktt` spells out. `Amc*` → the PDK's `<xy>_mm` sections; `Kmc` includes only the Monte Carlo parameter files.

## Claims withdrawn rather than fixed

Where I could not verify, the pages now say so instead of guessing:

- **`variable: CPDK_NGPICE`** — cicsim 0.2.7 never reads the `variable` block (only `ngspice`, `spectre`, `cadence`, `corner`, `options`). My explanation of what the path was for was invented. The page now warns that changing it may do nothing.
- **`grid` and `spiceunit`** — cicpy loads both into `Rules` and never uses them. My "manufacturing grid" and "scale factor for device properties" glosses are gone. Relatedly, magic output snaps to 50 Å = 5 nm, hard coded in `MagicPrinter`, *not* taken from `grid`.
- **`cthresh` and `extresist tolerance` units** — magic isn't installed in this environment and opencircuitdesign.com is unreachable from it. These now describe which way the knob turns and point at magic's docs.
- **The `VIA4` 28 → 32 change** is described as a sub-micron via dimension, which is what the commit message supports, rather than as an exact sky130 rule.

## What I did verify and leave alone

`cicsim run`/`simcell`/`summary` signatures and the comma cross-product; the make targets and tcl templates (read from the files); the `script/` and `py/` pages (read from their sources); `render_gds.py`; the corner temperatures and voltages; the layer and device maps in `sky130A.tech`.

Still resting on convention, not verification: that `sf` means slow-nfet / fast-pfet. That is sky130 naming, and no PDK is installed here.

## Verified

`mkdocsite.py --check` clean, `jekyll build` 83 pages, 0 broken internal links.