### PR TITLE
make: build the gds before kdrc in `check`

### DIFF
--- a/make/core.make
+++ b/make/core.make
@@ -341,7 +341,13 @@ rebuild:
 rebuildall: rebuild checkall
 
 #- What "checked" means for one cell. Both decks, connectivity, antenna.
-check: cdl drc kdrc lvs ant
+#-
+#- gds comes before kdrc because kdrc READS gds/${PRCELL}.gds and has no
+#- dependency on it: without this, `check` runs klayout over whatever
+#- gds was last written and reports a verdict on the previous layout.
+#- Measured: after moving LELO_TEMP onto a local bipolar, `check` still
+#- read a gds from the day before and called the cell KDRC FAIL.
+check: cdl drc gds kdrc lvs ant
 
 #- ... and for every cell the IP lists.
 checkall:


### PR DESCRIPTION
`check` is the target that claims a cell has been verified:

    check: cdl drc kdrc lvs ant

`kdrc` reads `gds/${PRCELL}.gds` and has no dependency on it, and
nothing in the chain builds it. So klayout was run over whatever the
last `make gds` happened to leave there, and the verdict belongs to
that layout rather than the one under test.

## Measured

On `LELO_TEMP`, after repointing it at a local copy of the bandgap's
bipolar, one `make rebuildall` produced both failure modes at once:

| cell | reported | actually |
| :-- | :-- | :-- |
| `LELOTEMP_BIAS_IBP` | KDRC FAIL, 10x psdm.1 | clean -- the gds beside it was from the previous day, and 10 psdm.1 is the exact count the fix had just removed |
| `LELO_TEMP` | KDRC OK | also off a stale gds, which happened to agree |

The false OK is the dangerous half: a green result from a check that
never looked at the cell is worse than no result.

## The fix

    check: cdl drc gds kdrc lvs ant

`kdrcall` already pairs the two targets; `check` now does the same, so
`check` and `checkall`/`rebuildall` above it judge the layout they
were pointed at. The comment records the measurement beside the line.

Every IP's `make check` reads this file. Re-verified after the change
on the five cells of lelo_temp_sky130a -- DRC OK, KDRC OK, LVS
"Circuits match uniquely" at every level (lelo_temp_sky130a#1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2NXKz4pJqzwkkQt9GQ19N